### PR TITLE
Add Related Patches section to patch detail pages

### DIFF
--- a/amplify/backend.ts
+++ b/amplify/backend.ts
@@ -14,6 +14,7 @@ import { createCheckout } from './functions/create-checkout/resource';
 import { stripeWebhook } from './functions/stripe-webhook/resource';
 import { listUsers } from './functions/list-users/resource';
 import { getPatchProgress } from './functions/get-patch-progress/resource';
+import { getRelatedPatches } from './functions/get-related-patches/resource';
 
 const backend = defineBackend({
   auth,
@@ -23,6 +24,7 @@ const backend = defineBackend({
   stripeWebhook,
   listUsers,
   getPatchProgress,
+  getRelatedPatches,
 });
 
 // ─── S3: allow public read on public/* (matches Gen1 behavior) ───────────────
@@ -66,6 +68,10 @@ stripeWebhookFn.addEnvironment('APPSYNC_API_KEY', apiKey);
 
 getPatchProgressFn.addEnvironment('APPSYNC_URL', graphqlUrl);
 getPatchProgressFn.addEnvironment('APPSYNC_API_KEY', apiKey);
+
+const getRelatedPatchesFn = backend.getRelatedPatches.resources.lambda as lambda.Function;
+getRelatedPatchesFn.addEnvironment('APPSYNC_URL', graphqlUrl);
+getRelatedPatchesFn.addEnvironment('APPSYNC_API_KEY', apiKey);
 
 // ─── IAM grants ──────────────────────────────────────────────────────────────
 

--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -1,6 +1,7 @@
 import { type ClientSchema, a, defineData } from '@aws-amplify/backend';
 import { getPatchProgress } from '../functions/get-patch-progress/resource';
 import { listUsers } from '../functions/list-users/resource';
+import { getRelatedPatches } from '../functions/get-related-patches/resource';
 
 const schema = a.schema({
   // ─── Enums ────────────────────────────────────────────────────────────────
@@ -18,6 +19,20 @@ const schema = a.schema({
     denom: a.float().required(),
     percent: a.integer().required(),
     note: a.string(),
+  }),
+
+  RelatedPatch: a.customType({
+    id: a.id().required(),
+    name: a.string().required(),
+    description: a.string(),
+    imageUrl: a.string(),
+    regions: a.string().array(),
+    difficulty: a.ref('Difficulty'),
+    hasPeaks: a.boolean(),
+    hasTrails: a.boolean(),
+    popularity: a.integer(),
+    isPurchasable: a.boolean(),
+    matchScore: a.integer().required(),
   }),
 
   // ─── Models ────────────────────────────────────────────────────────────────
@@ -219,6 +234,16 @@ const schema = a.schema({
     .returns(a.ref('PatchProgress').required().array().required())
     .authorization((allow) => [allow.authenticated()])
     .handler(a.handler.function(getPatchProgress)),
+
+  getRelatedPatches: a
+    .query()
+    .arguments({
+      patchId: a.id().required(),
+      limit: a.integer(),
+    })
+    .returns(a.ref('RelatedPatch').required().array().required())
+    .authorization((allow) => [allow.publicApiKey(), allow.authenticated()])
+    .handler(a.handler.function(getRelatedPatches)),
 }).authorization((allow) => [
   allow.resource(getPatchProgress).to(['query']),
   allow.resource(listUsers).to(['query']),

--- a/amplify/functions/get-related-patches/handler.ts
+++ b/amplify/functions/get-related-patches/handler.ts
@@ -1,0 +1,226 @@
+import type { AppSyncResolverHandler } from 'aws-lambda';
+
+type RelatedPatchesArgs = {
+  patchId: string;
+  limit?: number | null;
+};
+
+interface RelatedPatch {
+  id: string;
+  name: string;
+  description: string | null;
+  imageUrl: string | null;
+  regions: (string | null)[] | null;
+  difficulty: string | null;
+  hasPeaks: boolean | null;
+  hasTrails: boolean | null;
+  popularity: number | null;
+  isPurchasable: boolean | null;
+  matchScore: number;
+}
+
+const DEFAULT_LIMIT = 6;
+const MAX_LIMIT = 12;
+const MOUNTAIN_WEIGHT = 3;
+const TRAIL_WEIGHT = 3;
+const REGION_WEIGHT = 1;
+
+/** ---- GraphQL operations ---- */
+const GQL_getPatch = `
+  query GetPatch($id: ID!) {
+    getPatch(id: $id) { id regions status }
+  }
+`;
+const GQL_patchMountainsByPatch = `
+  query PatchMountainsByPatch($patchId: ID!, $limit: Int, $nextToken: String) {
+    patchMountainsByPatch(patchPatchMountainsId: $patchId, limit: $limit, nextToken: $nextToken) {
+      items { mountainPatchMountainsId delisted }
+      nextToken
+    }
+  }
+`;
+const GQL_patchTrailsByPatch = `
+  query PatchTrailsByPatch($patchId: ID!, $limit: Int, $nextToken: String) {
+    patchTrailsByPatch(patchPatchTrailsId: $patchId, limit: $limit, nextToken: $nextToken) {
+      items { trailPatchTrailsId }
+      nextToken
+    }
+  }
+`;
+const GQL_patchMountainsByMountain = `
+  query PatchMountainsByMountain($mountainId: ID!, $limit: Int, $nextToken: String) {
+    patchMountainsByMountain(mountainPatchMountainsId: $mountainId, limit: $limit, nextToken: $nextToken) {
+      items { patchPatchMountainsId delisted }
+      nextToken
+    }
+  }
+`;
+const GQL_patchTrailsByTrail = `
+  query PatchTrailsByTrail($trailId: ID!, $limit: Int, $nextToken: String) {
+    patchTrailsByTrail(trailPatchTrailsId: $trailId, limit: $limit, nextToken: $nextToken) {
+      items { patchPatchTrailsId }
+      nextToken
+    }
+  }
+`;
+const GQL_listPatches = `
+  query ListPatches($limit: Int, $nextToken: String) {
+    listPatches(limit: $limit, nextToken: $nextToken) {
+      items {
+        id
+        name
+        description
+        imageUrl
+        regions
+        difficulty
+        hasPeaks
+        hasTrails
+        popularity
+        isPurchasable
+        status
+      }
+      nextToken
+    }
+  }
+`;
+
+/** ---- AppSync access (apiKey only — all reads here are public) ---- */
+async function graphQL<T>(query: string, variables: Record<string, unknown>): Promise<T> {
+  const endpoint = process.env.APPSYNC_URL!;
+  const apiKey = process.env.APPSYNC_API_KEY!;
+  const res = await fetch(endpoint, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'x-api-key': apiKey },
+    body: JSON.stringify({ query, variables }),
+  });
+  const json = (await res.json()) as { data: T; errors?: unknown[] };
+  if (!res.ok || json.errors) throw new Error(`AppSync error: ${JSON.stringify(json.errors ?? json)}`);
+  return json.data;
+}
+
+/** ---- Pagination helper ---- */
+async function fetchAllPages<TItem>(query: string, variables: Record<string, unknown>, fieldName: string): Promise<TItem[]> {
+  type Connection = { items: TItem[] | null; nextToken?: string | null } | null;
+  const out: TItem[] = [];
+  let nextToken: string | null = null;
+  do {
+    const data: Record<string, Connection> = await graphQL<Record<string, Connection>>(query, {
+      ...variables,
+      limit: 200,
+      nextToken,
+    });
+    const conn: Connection = data[fieldName];
+    if (conn?.items?.length) out.push(...conn.items);
+    nextToken = conn?.nextToken ?? null;
+  } while (nextToken);
+  return out;
+}
+
+/** ---- Data shapes ---- */
+interface PatchMountainRow {
+  mountainPatchMountainsId: string | null;
+  delisted: boolean | null;
+}
+interface PatchTrailRow {
+  trailPatchTrailsId: string | null;
+}
+interface SiblingPatchMountainRow {
+  patchPatchMountainsId: string | null;
+  delisted: boolean | null;
+}
+interface SiblingPatchTrailRow {
+  patchPatchTrailsId: string | null;
+}
+interface PatchListItem {
+  id: string;
+  name: string;
+  description: string | null;
+  imageUrl: string | null;
+  regions: (string | null)[] | null;
+  difficulty: string | null;
+  hasPeaks: boolean | null;
+  hasTrails: boolean | null;
+  popularity: number | null;
+  isPurchasable: boolean | null;
+  status: string | null;
+}
+
+function isExcludedStatus(status: string | null | undefined): boolean {
+  return status === 'ARCHIVED' || status === 'DRAFT';
+}
+
+/** ---- Handler ---- */
+export const handler: AppSyncResolverHandler<RelatedPatchesArgs, RelatedPatch[]> = async (event) => {
+  const { patchId } = event.arguments;
+  const limit = Math.max(1, Math.min(MAX_LIMIT, event.arguments.limit ?? DEFAULT_LIMIT));
+
+  const [target, patchMountains, patchTrails, allPatches] = await Promise.all([
+    graphQL<{ getPatch: { id: string; regions: (string | null)[] | null; status: string | null } | null }>(GQL_getPatch, { id: patchId }),
+    fetchAllPages<PatchMountainRow>(GQL_patchMountainsByPatch, { patchId }, 'patchMountainsByPatch'),
+    fetchAllPages<PatchTrailRow>(GQL_patchTrailsByPatch, { patchId }, 'patchTrailsByPatch'),
+    fetchAllPages<PatchListItem>(GQL_listPatches, {}, 'listPatches'),
+  ]);
+
+  const targetRegions = new Set((target.getPatch?.regions ?? []).filter((r): r is string => !!r));
+
+  const mountainIds = patchMountains
+    .filter((row) => !row.delisted && row.mountainPatchMountainsId)
+    .map((row) => row.mountainPatchMountainsId as string);
+
+  const trailIds = patchTrails
+    .filter((row) => row.trailPatchTrailsId)
+    .map((row) => row.trailPatchTrailsId as string);
+
+  const sharedMountains = new Map<string, number>();
+  const sharedTrails = new Map<string, number>();
+
+  await Promise.all([
+    ...mountainIds.map(async (mountainId) => {
+      const rows = await fetchAllPages<SiblingPatchMountainRow>(GQL_patchMountainsByMountain, { mountainId }, 'patchMountainsByMountain');
+      for (const row of rows) {
+        const otherId = row.patchPatchMountainsId;
+        if (!otherId || otherId === patchId || row.delisted) continue;
+        sharedMountains.set(otherId, (sharedMountains.get(otherId) ?? 0) + 1);
+      }
+    }),
+    ...trailIds.map(async (trailId) => {
+      const rows = await fetchAllPages<SiblingPatchTrailRow>(GQL_patchTrailsByTrail, { trailId }, 'patchTrailsByTrail');
+      for (const row of rows) {
+        const otherId = row.patchPatchTrailsId;
+        if (!otherId || otherId === patchId) continue;
+        sharedTrails.set(otherId, (sharedTrails.get(otherId) ?? 0) + 1);
+      }
+    }),
+  ]);
+
+  const scored = allPatches
+    .filter((p) => p.id !== patchId && !isExcludedStatus(p.status))
+    .map((p) => {
+      const regions = (p.regions ?? []).filter((r): r is string => !!r);
+      const sharedRegionCount = regions.filter((r) => targetRegions.has(r)).length;
+      const score =
+        MOUNTAIN_WEIGHT * (sharedMountains.get(p.id) ?? 0) +
+        TRAIL_WEIGHT * (sharedTrails.get(p.id) ?? 0) +
+        REGION_WEIGHT * sharedRegionCount;
+      return { patch: p, score };
+    });
+
+  scored.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    return (b.patch.popularity ?? -1) - (a.patch.popularity ?? -1);
+  });
+
+  return scored.slice(0, limit).map(({ patch, score }) => ({
+    id: patch.id,
+    name: patch.name,
+    description: patch.description,
+    imageUrl: patch.imageUrl,
+    regions: patch.regions,
+    difficulty: patch.difficulty,
+    hasPeaks: patch.hasPeaks,
+    hasTrails: patch.hasTrails,
+    popularity: patch.popularity,
+    isPurchasable: patch.isPurchasable,
+    matchScore: score,
+  }));
+};

--- a/amplify/functions/get-related-patches/resource.ts
+++ b/amplify/functions/get-related-patches/resource.ts
@@ -1,0 +1,7 @@
+import { defineFunction } from '@aws-amplify/backend';
+
+export const getRelatedPatches = defineFunction({
+  name: 'get-related-patches',
+  entry: './handler.ts',
+  resourceGroupName: 'data',
+});

--- a/amplify_outputs.json
+++ b/amplify_outputs.json
@@ -1588,6 +1588,91 @@
               "attributes": []
             }
           }
+        },
+        "RelatedPatch": {
+          "name": "RelatedPatch",
+          "fields": {
+            "id": {
+              "name": "id",
+              "isArray": false,
+              "type": "ID",
+              "isRequired": true,
+              "attributes": []
+            },
+            "name": {
+              "name": "name",
+              "isArray": false,
+              "type": "String",
+              "isRequired": true,
+              "attributes": []
+            },
+            "description": {
+              "name": "description",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "imageUrl": {
+              "name": "imageUrl",
+              "isArray": false,
+              "type": "String",
+              "isRequired": false,
+              "attributes": []
+            },
+            "regions": {
+              "name": "regions",
+              "isArray": true,
+              "type": "String",
+              "isRequired": false,
+              "attributes": [],
+              "isArrayNullable": true
+            },
+            "difficulty": {
+              "name": "difficulty",
+              "isArray": false,
+              "type": {
+                "enum": "Difficulty"
+              },
+              "isRequired": false,
+              "attributes": []
+            },
+            "hasPeaks": {
+              "name": "hasPeaks",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+            },
+            "hasTrails": {
+              "name": "hasTrails",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+            },
+            "popularity": {
+              "name": "popularity",
+              "isArray": false,
+              "type": "Int",
+              "isRequired": false,
+              "attributes": []
+            },
+            "isPurchasable": {
+              "name": "isPurchasable",
+              "isArray": false,
+              "type": "Boolean",
+              "isRequired": false,
+              "attributes": []
+            },
+            "matchScore": {
+              "name": "matchScore",
+              "isArray": false,
+              "type": "Int",
+              "isRequired": true,
+              "attributes": []
+            }
+          }
         }
       },
       "queries": {
@@ -1634,6 +1719,29 @@
               "isArray": false,
               "type": "ID",
               "isRequired": true
+            }
+          }
+        },
+        "getRelatedPatches": {
+          "name": "getRelatedPatches",
+          "isArray": true,
+          "type": {
+            "nonModel": "RelatedPatch"
+          },
+          "isRequired": true,
+          "isArrayNullable": false,
+          "arguments": {
+            "patchId": {
+              "name": "patchId",
+              "isArray": false,
+              "type": "ID",
+              "isRequired": true
+            },
+            "limit": {
+              "name": "limit",
+              "isArray": false,
+              "type": "Int",
+              "isRequired": false
             }
           }
         }

--- a/app/patch/[id]/PatchDetailClient.tsx
+++ b/app/patch/[id]/PatchDetailClient.tsx
@@ -15,7 +15,9 @@ import PatchMountains from '@/components/PatchMountains';
 import PatchProgress from '@/components/PatchProgress';
 import PatchTrails from '@/components/PatchTrails';
 import ProgressSummary from '@/components/ProgressSummary';
+import PatchGrid from '@/components/PatchGrid';
 import { usePatchProgressSummary } from '@/hooks/usePatchProgressSummary';
+import { useRelatedPatches } from '@/hooks/useRelatedPatches';
 
 type UserMountainMap = {
   [mountainID: string]: UserMountain[];
@@ -250,6 +252,8 @@ export default function PatchDetailClient({ id }: { id: string }) {
     refresh: refreshProgress,
   } = usePatchProgressSummary(patch?.id ?? null, user?.userId ?? null);
 
+  const { patches: relatedPatches, loading: loadingRelated } = useRelatedPatches(patch?.id ?? null);
+
   const progressUnit = useMemo<'miles' | null>(() => {
     const raw: unknown = (patch as any)?.completionRule;
     if (!raw) return null;
@@ -415,6 +419,13 @@ export default function PatchDetailClient({ id }: { id: string }) {
               </div>
             )}
           </>
+        )}
+
+        {!loadingRelated && relatedPatches.length > 0 && (
+          <div className="bg-white p-4 rounded shadow mt-6">
+            <h2 className="text-lg font-semibold mb-3">Related Patches</h2>
+            <PatchGrid patches={relatedPatches} />
+          </div>
         )}
       </div>
     </>

--- a/src/API.ts
+++ b/src/API.ts
@@ -718,6 +718,21 @@ export type PatchProgress = {
   note?: string | null,
 };
 
+export type RelatedPatch = {
+  __typename: "RelatedPatch",
+  id: string,
+  name: string,
+  description?: string | null,
+  imageUrl?: string | null,
+  regions?: Array< string | null > | null,
+  difficulty?: Difficulty | null,
+  hasPeaks?: boolean | null,
+  hasTrails?: boolean | null,
+  popularity?: number | null,
+  isPurchasable?: boolean | null,
+  matchScore: number,
+};
+
 export type ModelPatchFilterInput = {
   id?: ModelIDInput | null,
   name?: ModelStringInput | null,
@@ -2509,6 +2524,28 @@ export type ListPatchProgressQuery = {
     denom: number,
     percent: number,
     note?: string | null,
+  } >,
+};
+
+export type GetRelatedPatchesQueryVariables = {
+  patchId: string,
+  limit?: number | null,
+};
+
+export type GetRelatedPatchesQuery = {
+  getRelatedPatches:  Array< {
+    __typename: "RelatedPatch",
+    id: string,
+    name: string,
+    description?: string | null,
+    imageUrl?: string | null,
+    regions?: Array< string | null > | null,
+    difficulty?: Difficulty | null,
+    hasPeaks?: boolean | null,
+    hasTrails?: boolean | null,
+    popularity?: number | null,
+    isPurchasable?: boolean | null,
+    matchScore: number,
   } >,
 };
 

--- a/src/components/PatchCard.tsx
+++ b/src/components/PatchCard.tsx
@@ -4,8 +4,13 @@ import { PatchDisplay } from './PatchDisplay';
 import UserProgressOverlay from '@/components/UserProgressOverlay';
 import WishHeartButton from '@/components/WishHeartButton';
 
+export type PatchCardData = Pick<
+  Patch,
+  'id' | 'name' | 'description' | 'regions' | 'difficulty' | 'imageUrl' | 'hasPeaks' | 'hasTrails'
+>;
+
 type Props = {
-  patch: Patch;
+  patch: PatchCardData;
   status?: '' | 'In Progress' | 'Completed';
   wishInit?: boolean;
   onWishlistChange?: (patchId: string, next: boolean) => void;
@@ -13,8 +18,7 @@ type Props = {
 
 export function PatchCard({ patch, status = '', wishInit = false, onWishlistChange }: Props) {
   // Show overlay if the patch tracks EITHER peaks or trails
-  const hasProgress =
-    Boolean((patch as any).hasPeaks) || Boolean((patch as any).hasTrails);
+  const hasProgress = Boolean(patch.hasPeaks) || Boolean(patch.hasTrails);
 
   const topRight = (
     <div className="inline-flex items-center gap-2">

--- a/src/components/PatchGrid.tsx
+++ b/src/components/PatchGrid.tsx
@@ -1,11 +1,10 @@
 // src/components/PatchGrid.tsx
-import { Patch } from '@/API';
-import { PatchCard } from '@/components/PatchCard';
+import { PatchCard, PatchCardData } from '@/components/PatchCard';
 
 type UserPatchLite = { dateCompleted: string | null; inProgress: boolean; wishlisted?: boolean };
 
 type PatchGridProps = {
-  patches: Patch[];
+  patches: PatchCardData[];
   userPatchMap?: Map<string, UserPatchLite>;
   userDataReady?: boolean;
   wishlistSet?: Set<string>; 

--- a/src/graphql/queries.ts
+++ b/src/graphql/queries.ts
@@ -38,6 +38,26 @@ export const listPatchProgress = /* GraphQL */ `query ListPatchProgress($patchId
   APITypes.ListPatchProgressQueryVariables,
   APITypes.ListPatchProgressQuery
 >;
+export const getRelatedPatches = /* GraphQL */ `query GetRelatedPatches($limit: Int, $patchId: ID!) {
+  getRelatedPatches(limit: $limit, patchId: $patchId) {
+    description
+    difficulty
+    hasPeaks
+    hasTrails
+    id
+    imageUrl
+    isPurchasable
+    matchScore
+    name
+    popularity
+    regions
+    __typename
+  }
+}
+` as GeneratedQuery<
+  APITypes.GetRelatedPatchesQueryVariables,
+  APITypes.GetRelatedPatchesQuery
+>;
 export const getPatch = /* GraphQL */ `query GetPatch($id: ID!) {
   getPatch(id: $id) {
     id

--- a/src/hooks/useRelatedPatches.ts
+++ b/src/hooks/useRelatedPatches.ts
@@ -1,0 +1,40 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { generateClient } from 'aws-amplify/api';
+import { getRelatedPatches } from '@/graphql/queries';
+import type { GetRelatedPatchesQuery } from '@/API';
+
+const client = generateClient();
+
+export function useRelatedPatches(patchId: string | null, limit = 6) {
+  const [patches, setPatches] = useState<GetRelatedPatchesQuery['getRelatedPatches']>([]);
+  const [loading, setLoading] = useState<boolean>(!!patchId);
+
+  useEffect(() => {
+    if (!patchId) {
+      setPatches([]);
+      setLoading(false);
+      return;
+    }
+
+    let alive = true;
+    setLoading(true);
+
+    client
+      .graphql({ query: getRelatedPatches, variables: { patchId, limit } })
+      .then((r) => {
+        if (alive) setPatches(r.data?.getRelatedPatches ?? []);
+      })
+      .catch((e) => console.error('getRelatedPatches failed:', e))
+      .finally(() => {
+        if (alive) setLoading(false);
+      });
+
+    return () => {
+      alive = false;
+    };
+  }, [patchId, limit]);
+
+  return { patches, loading };
+}


### PR DESCRIPTION
## Summary
- New `getRelatedPatches` AppSync custom query backed by a Lambda (`amplify/functions/get-related-patches/`), colocated in the `data` stack (same pattern as `getPatchProgress`)
- Scores sibling patches by shared Mountains/Trails (via `PatchMountain`/`PatchTrail` join indexes, weight 3) and shared `regions` (weight 1), falling back to popularity-sorted results when there's no overlap
- New `useRelatedPatches` hook + `PatchCardData` type (loosens `PatchCard`/`PatchGrid` props so `RelatedPatch[]` results render via the existing grid)
- New "Related Patches" section on `/patch/[id]` for both signed-in and anonymous users

## Test plan
- [x] `tsc --noEmit` passes
- [x] Verified mountain/trail-overlap scoring (e.g. "Over 70 48 4k" → Northeast 111, NH 48 4K, ADK 46er)
- [x] Verified region-overlap fallback for patches with no peaks/trails (e.g. "AMC SEM 500 Mile Patch" → other Massachusetts patches)
- [x] Click-through navigation from a related card to its own `/patch/[id]` page
- [x] Signed-in view: wishlist heart toggles correctly on related cards with no console errors
- [x] Signed-out view renders the section identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)